### PR TITLE
Downgrade CMake 3.17 -> 3.16 for CLion IDE users to build the project and enjoy intelligent code completion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.16)
 
 # define project
 

--- a/deps/glad/CMakeLists.txt
+++ b/deps/glad/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.16)
 
 project(glad LANGUAGES CXX)
 

--- a/deps/imgui/CMakeLists.txt
+++ b/deps/imgui/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.16)
 
 project(imgui LANGUAGES CXX)
 

--- a/deps/nfd/CMakeLists.txt
+++ b/deps/nfd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.16)
 
 if(UNIX AND NOT APPLE)
 	set(LINUX TRUE)

--- a/deps/sf_libs/CMakeLists.txt
+++ b/deps/sf_libs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.16)
 
 project(sf_libs LANGUAGES CXX)
 


### PR DESCRIPTION
Hi thanks for this interesting assignment! There are many CLion IDE users. The latest IDE currently only supports CMake 3.16, and it seems that this project does not need those latest features introduced in CMake 3.17. Therefore, I am making this PR to allow CLion IDE users to build the project and enjoy intelligent code completion.