### PR TITLE
fix broken links (mostly in A2 MeshEdit)

### DIFF
--- a/docs/meshedit/bevel.md
+++ b/docs/meshedit/bevel.md
@@ -15,7 +15,7 @@ Here we provide some additional detail about the bevel operations and their impl
 
 The methods that update the connectivity are `HalfedgeMesh::bevel_vertex`, `halfedgeMesh::bevel_edge`, and `HalfedgeMesh::bevel_face`. The methods that update geometry are `HalfedgeMesh::bevel_vertex_positions`, `HalfedgeMesh::bevel_edge_positions`, and `HalfedgeMesh::bevel_face_positions`.
 
-The methods for updating connectivity can be implemented following the general strategy outlined in [edge flip tutorial](edge_flip). **Note that the methods that update geometry will be called repeatedly for the same bevel, in order to adjust positions according to user mouse input. See the gif in the [User Guide](../guide/model).**
+The methods for updating connectivity can be implemented following the general strategy outlined in [edge flip tutorial](edge_flip). **Note that the methods that update geometry will be called repeatedly for the same bevel, in order to adjust positions according to user mouse input. See the gif in the [User Guide](../guide/model_mode).**
 
 To update the _geometry_ of a beveled element, you are provided with the following data:
 

--- a/docs/meshedit/bevel.md
+++ b/docs/meshedit/bevel.md
@@ -15,7 +15,7 @@ Here we provide some additional detail about the bevel operations and their impl
 
 The methods that update the connectivity are `HalfedgeMesh::bevel_vertex`, `halfedgeMesh::bevel_edge`, and `HalfedgeMesh::bevel_face`. The methods that update geometry are `HalfedgeMesh::bevel_vertex_positions`, `HalfedgeMesh::bevel_edge_positions`, and `HalfedgeMesh::bevel_face_positions`.
 
-The methods for updating connectivity can be implemented following the general strategy outlined in [edge flip tutorial](edge_flip). **Note that the methods that update geometry will be called repeatedly for the same bevel, in order to adjust positions according to user mouse input. See the gif in the [User Guide](../guide/model_mode).**
+The methods for updating connectivity can be implemented following the general strategy outlined in [edge flip tutorial](edge_flip). **Note that the methods that update geometry will be called repeatedly for the same bevel, in order to adjust positions according to user mouse input. See the gif in the [User Guide](/Scotty3D/guide/model_mode).**
 
 To update the _geometry_ of a beveled element, you are provided with the following data:
 

--- a/docs/meshedit/catmull.md
+++ b/docs/meshedit/catmull.md
@@ -8,7 +8,7 @@ permalink: /meshedit/global/catmull/
 
 # Catmull-Clark Subdivision
 
-For an in-practice example, see the [User Guide](/Scotty3D/guide/model).
+For an in-practice example, see the [User Guide](/Scotty3D/guide/model_mode).
 
 The only difference between Catmull-Clark and [linear](../linear) subdivision is the choice of positions for new vertices. Whereas linear subdivision simply takes a uniform average of the old vertex positions, Catmull-Clark uses a very carefully-designed _weighted_ average to ensure that the surface converges to a nice, round surface as the number of subdivision steps increases. The original scheme is described in the paper _"Recursively generated B-spline surfaces on arbitrary topological meshes"_ by (Pixar co-founder) Ed Catmull and James Clark. Since then, the scheme has been thoroughly discussed, extended, and analyzed; more modern descriptions of the algorithm may be easier to read, including those from the [Wikipedia](https://en.wikipedia.org/wiki/Catmull-Clark_subdivision_surface) and [this webpage](http://www.rorydriscoll.com/2008/08/01/catmull-clark-subdivision-the-basics/). In short, the new vertex positions can be calculated by:
 

--- a/docs/meshedit/global.md
+++ b/docs/meshedit/global.md
@@ -10,7 +10,7 @@ nav_order: 2
 
 # Global Mesh Operations
 
-In addition to local operations on mesh connectivity, Scotty3D provides several global remeshing operations (as outlined in the [User Guide](/Scotty3D/guide/model)). Two different mechanisms are used to implement global operations:
+In addition to local operations on mesh connectivity, Scotty3D provides several global remeshing operations (as outlined in the [User Guide](/Scotty3D/guide/model_mode)). Two different mechanisms are used to implement global operations:
 
 *   _Repeated application of local operations._ Some mesh operations are most easily expressed by applying local operations (edge flips, etc.) to a sequence of mesh elements until the target output is achieved. A good example is [mesh simplification](simplify), which is a greedy algorithm that collapses one edge at a time.
 *   _Global replacement of the mesh._ Other mesh operations are better expressed by temporarily storing new mesh elements in a simpler mesh data structure (e.g., an indexed list of faces) and completely re-building the halfedge data structure from this data. A good example is [Catmull-Clark subdivision](catmull), where every polygon must be simultaneously split into quadrilaterals.

--- a/docs/meshedit/linear.md
+++ b/docs/meshedit/linear.md
@@ -8,7 +8,7 @@ grand_parent: "A2: MeshEdit"
 
 # Linear Subdivision
 
-For an in-practice example, see the [User Guide](/Scotty3D/guide/model).
+For an in-practice example, see the [User Guide](/Scotty3D/guide/model_mode).
 
 Unlike most other global remeshing operations, linear (and Catmull-Clark) subdivision will proceed by completely replacing the original halfedge mesh with a new one. The high-level procedure is:
 

--- a/docs/meshedit/local.md
+++ b/docs/meshedit/local.md
@@ -27,7 +27,7 @@ To facilitate user interaction, as well as global mesh processing operations (de
 
 Also, remember that in any case, _the program should not crash!_ So for instance, you should never return a pointer to an element that was deleted.
 
-See the [User Guide](/Scotty3D/guide/model) for demonstrations of each local operation.
+See the [User Guide](/Scotty3D/guide/model_mode) for demonstrations of each local operation.
 
 *   `Halfedge_Mesh::flip_edge` - should return the edge that was flipped
 

--- a/docs/meshedit/loop.md
+++ b/docs/meshedit/loop.md
@@ -8,7 +8,7 @@ grand_parent: "A2: MeshEdit"
 
 # Loop Subdivision
 
-For an in-practice example, see the [User Guide](/Scotty3D/guide/model).
+For an in-practice example, see the [User Guide](/Scotty3D/guide/model_mode).
 
 Loop subdivision (named after [Charles Loop](http://charlesloop.com/)) is a standard approximating subdivision scheme for triangle meshes. At a high level, it consists of two basic steps:
 

--- a/docs/meshedit/remesh.md
+++ b/docs/meshedit/remesh.md
@@ -8,7 +8,7 @@ grand_parent: "A2: MeshEdit"
 
 # Isotropic Remeshing
 
-For an in-practice example, see the [User Guide](/Scotty3D/guide/model).
+For an in-practice example, see the [User Guide](/Scotty3D/guide/model_mode).
 
 Scotty3D also supports remeshing, an operation that keeps the number of samples roughly the same while improving the shape of individual triangles. The isotropic remeshing algorithm tries to make the mesh as "uniform" as possible, i.e., triangles as close as possible to equilateral triangles of equal size, and vertex degrees as close as possible to 6 (note: this algorithm is for **triangle meshes only**). The algorithm to be implemented is based on the paper [Botsch and Kobbelt, "A Remeshing Approach to Multiresolution Modeling"](http://graphics.uni-bielefeld.de/publications/disclaimer.php?dlurl=sgp04.pdf) (Section 4), and can be summarized in just a few simple steps:
 

--- a/docs/meshedit/simplify.md
+++ b/docs/meshedit/simplify.md
@@ -10,7 +10,7 @@ grand_parent: "A2: MeshEdit"
 
 ![Surface simplification via quadric error metric](quad_simplify.png)
 
-For an in-practice example, see the [User Guide](/Scotty3D/guide/model).
+For an in-practice example, see the [User Guide](/Scotty3D/guide/model_mode).
 
 Just as with images, meshes often have far more samples than we really need. The simplification method in Scotty3D simplifies a given triangle mesh by applying _quadric error simplification_ (note that this method is for **triangle meshes only**!). This method was originally developed at CMU by Michael Garland and Paul Heckbert, in their paper [Surface Simplification Using Quadric Error Metrics](http://www.cs.cmu.edu/~./garland/quadrics/quadrics.html). (Looking at this paper -- or the many slides and presentations online that reference it -- may be very helpful in understanding and implementing this part of the assignment!)
 

--- a/docs/meshedit/triangulate.md
+++ b/docs/meshedit/triangulate.md
@@ -8,7 +8,7 @@ grand_parent: "A2: MeshEdit"
 
 # Triangulation
 
-For an in-practice example, see the [User Guide](/Scotty3D/guide/model).
+For an in-practice example, see the [User Guide](/Scotty3D/guide/model_mode).
 
 A variety of geometry processing algorithms become easier to implement (or are only well defined) when the input consists purely of triangles. The method `Halfedge_Mesh::triangulate` converts any polygon mesh into a triangle mesh by splitting each polygon into triangles.
 


### PR DESCRIPTION
Hi thanks for the assignment! The links in MeshEdit seems to be broken, because they link to locations like https://cmu-graphics.github.io/Scotty3D/meshedit/local/guide/model, but actually that is moved to https://cmu-graphics.github.io/Scotty3D/guide/model_mode. This PR fixes the problem.