### PR TITLE
Update path_tracing.md - otherwise the ball in Cornell Box will be completely black

### DIFF
--- a/docs/pathtracer/path_tracing.md
+++ b/docs/pathtracer/path_tracing.md
@@ -35,7 +35,7 @@ Note:
 
 ---
 
-After correctly implementing path tracing, your renderer should be able to make a beautifully lit picture of the Cornell Box. Below is the rendering result of 1024 sample per pixel.
+After correctly implementing path tracing, your renderer should be able to make a beautifully lit picture of the Cornell Box. However, the provided `cbox.dae` is Glass material, but you have only implemented Lambertian. Therefore, you need to firstly modify the material of `cbox.dae` (probably using Scotty3D panels) to Lambertian before rendering. Below is the rendering result of 1024 sample per pixel.
 
 ![cornell_lambertian](new_results/lambertian.png)
 


### PR DESCRIPTION
Hi thanks for the assignment! After doing task 5 of assignment 3, I see a problem: The cornell box has completely black balls:

![image](https://user-images.githubusercontent.com/5236035/108844321-eea3c380-7616-11eb-82ba-2fdf486c24ae.png)

After a while I realized it may be caused by the material of the ball. If I change the material, now it is ok:

![5581614083295_ pic_hd](https://user-images.githubusercontent.com/5236035/108844063-8bb22c80-7616-11eb-8c9f-c15fb62b818a.jpg)

P.S. I am not sure whether it is a bug of my code, or it is because the material in reference page is actually *not* Lambertian - the shadow in my image is more sharp compared with the reference image in https://cmu-graphics.github.io/Scotty3D/pathtracer/path_tracing